### PR TITLE
Remove duplicate onOpen implementations

### DIFF
--- a/dateDiffRangeLogger.gs
+++ b/dateDiffRangeLogger.gs
@@ -64,10 +64,3 @@ function logDateDifferencesInRange() {
     }
   }
 }
-
-function onOpen() {
-  SpreadsheetApp.getUi()
-    .createMenu('LTD Tracker')
-    .addItem('Log Date Differences', 'logDateDifferencesInRange')
-    .addToUi();
-}

--- a/installOnOpenMenuTrigger.gs
+++ b/installOnOpenMenuTrigger.gs
@@ -2,6 +2,7 @@ function onOpen(e) {
   const ui = SpreadsheetApp.getUi();
   ui.createMenu('LTD Tracker')
     .addItem(APP_CONFIG.MENU_NAME, 'openSidebar')
+    .addItem('Log Date Differences', 'logDateDifferencesInRange')
     .addToUi();
   setHeaderStyle();
 }

--- a/sidebarUiService.gs
+++ b/sidebarUiService.gs
@@ -1,13 +1,3 @@
-function onOpen(e) {
-  SpreadsheetApp.getUi()
-    .createMenu('LTD Tracker')
-    .addItem('Open LTD Lifeline Sidebar', 'openSidebar')
-    .addToUi();
-}
-
-function onInstall(e) {
-  onOpen(e);
-}
 
 function openSidebar() {
   var template = HtmlService.createTemplateFromFile('Sidebar');


### PR DESCRIPTION
## Summary
- consolidate spreadsheet menu creation into a single `onOpen`
- remove unused `onOpen` and `onInstall` functions
- add "Log Date Differences" menu item to main `onOpen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549e0281a083279436556f29e9fbac