### PR TITLE
Add missing preference API functions

### DIFF
--- a/preferencesApi.gs
+++ b/preferencesApi.gs
@@ -1,0 +1,30 @@
+/**
+ * Fetches all user preferences for the preferences editor sidebar.
+ * @return {Object} mapping of preference keys to values
+ */
+function doGetPreferences() {
+  try {
+    return userPreferencesManager.getAll();
+  } catch (err) {
+    console.error('doGetPreferences error:', err);
+    throw err;
+  }
+}
+
+/**
+ * Saves the provided preferences using the userPreferencesManager.
+ * @param {Object} prefs Object where each key corresponds to a preference name
+ */
+function doSetPreference(prefs) {
+  try {
+    if (!prefs || typeof prefs !== 'object') {
+      throw new Error('Invalid prefs parameter');
+    }
+    Object.keys(prefs).forEach(function(key) {
+      userPreferencesManager.set(key, prefs[key]);
+    });
+  } catch (err) {
+    console.error('doSetPreference error:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `doGetPreferences` and `doSetPreference` for preferences sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549ef0f8dc8327982457ad915bb42e