### PR TITLE
Fix sidebar file references and constants

### DIFF
--- a/darkModeSidebarManager.html
+++ b/darkModeSidebarManager.html
@@ -1,5 +1,5 @@
 <!-- This file includes embedded JS/CSS due to project type rules -->
-<script>
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -188,4 +188,3 @@
   </script>
 </body>
 </html>
-</script>

--- a/preferencesSidebarEditor.html
+++ b/preferencesSidebarEditor.html
@@ -57,8 +57,8 @@
 
       function loadPreferences() {
         google.script.run
-          .withSuccessCallback(renderPrefs)
-          .withFailureCallback(handleLoadError)
+          .withSuccessHandler(renderPrefs)
+          .withFailureHandler(handleLoadError)
           .doGetPreferences();
       }
 
@@ -98,8 +98,8 @@
         saveBtn.disabled = true;
 
         google.script.run
-          .withSuccessCallback(closeSidebar)
-          .withFailureCallback(function(error) {
+          .withSuccessHandler(closeSidebar)
+          .withFailureHandler(function(error) {
             showError('Failed to save preferences: ' + (error.message || error));
             saveBtn.disabled = false;
           })

--- a/sheetReadWriteFormatter.gs
+++ b/sheetReadWriteFormatter.gs
@@ -91,3 +91,12 @@ function setHeaderStyle() {
        .setFontColor('#ffffff')
        .setFontWeight('bold');
 }
+
+var sheetReadWriteFormatter = {
+  getSheet: getSheet,
+  getSheetData: getSheetData,
+  updateStatus: updateStatus,
+  updateDaysLeft: updateDaysLeft,
+  hideRows: hideRows,
+  setHeaderStyle: setHeaderStyle
+};

--- a/sidebarUiService.gs
+++ b/sidebarUiService.gs
@@ -1,12 +1,12 @@
 
 function openSidebar() {
-  var template = HtmlService.createTemplateFromFile('Sidebar');
+  var template = HtmlService.createTemplateFromFile('darkModeSidebarManager');
   var html = template.evaluate().setTitle('LTD Lifeline');
   SpreadsheetApp.getUi().showSidebar(html);
 }
 
 function openSettingsSidebar() {
-  var template = HtmlService.createTemplateFromFile('SettingsSidebar');
+  var template = HtmlService.createTemplateFromFile('preferencesSidebarEditor');
   var html = template.evaluate().setTitle('LTD Lifeline Settings');
   SpreadsheetApp.getUi().showSidebar(html);
 }

--- a/updateRefundWindowStatus.gs
+++ b/updateRefundWindowStatus.gs
@@ -1,7 +1,7 @@
 var sheetService = sheetReadWriteFormatter;
 var notificationService = gmailAlertDispatcher;
 var formatDateDifference = dateDiffRangeLogger.formatDateDifference;
-var { REFUND_PERIOD_DAYS, REFUND_ALERT_THRESHOLD_DAYS, EMAIL_ON_ALERT } = APP_CONFIG;
+var { REFUND_PERIOD_DAYS, ALERT_THRESHOLD_DAYS, EMAIL_ON_ALERT } = APP_CONFIG;
 
 // provide batch methods on sheetService to avoid undefined errors
 sheetService.batchUpdateDaysLeft = function(updates) {
@@ -11,8 +11,8 @@ sheetService.batchUpdateDaysLeft = function(updates) {
 };
 sheetService.batchUpdateRefundAlertSent = function(rowIndexes) {
   rowIndexes.forEach(rowIndex => {
-    // assumes updateStatus can mark the refundAlertSent flag; adjust column/key as needed
-    sheetService.updateStatus(rowIndex, 'refundAlertSent', true);
+    // Mark alert sent using status column as a simple flag
+    sheetService.updateStatus(rowIndex, 'refundAlertSent');
   });
 };
 
@@ -36,7 +36,7 @@ function checkRefundWindow() {
       var daysLeft = REFUND_PERIOD_DAYS - daysUsed;
       daysLeftUpdates.push({ rowIndex: row.rowIndex, daysLeft: daysLeft });
 
-      var withinAlertWindow = daysLeft <= REFUND_ALERT_THRESHOLD_DAYS && daysLeft >= 0;
+      var withinAlertWindow = daysLeft <= ALERT_THRESHOLD_DAYS && daysLeft >= 0;
       var alreadyAlerted = Boolean(row.refundAlertSent);
       if (EMAIL_ON_ALERT && withinAlertWindow && !alreadyAlerted) {
         notificationService.sendEmailAlert(Object.assign({}, row, { daysLeft: daysLeft }), 'refund');


### PR DESCRIPTION
## Summary
- point sidebar functions to existing HTML files
- fix callback names in the preferences editor
- clean up dark mode sidebar HTML
- expose formatter functions via `sheetReadWriteFormatter`
- correct constant name in refund logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549f9f34a08327805161cdd7ae5d56