### PR TITLE
Open Deals sheet when sidebar shows

### DIFF
--- a/sidebarUiService.gs
+++ b/sidebarUiService.gs
@@ -3,6 +3,10 @@ function openSidebar() {
   var template = HtmlService.createTemplateFromFile('darkModeSidebarManager');
   var html = template.evaluate().setTitle('LTD Lifeline');
   SpreadsheetApp.getUi().showSidebar(html);
+  // Ensure the Deals sheet is activated when the sidebar loads
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var dealsSheet = ss.getSheetByName(APP_CONFIG.SHEET_NAME);
+  if (dealsSheet) dealsSheet.activate();
 }
 
 function openSettingsSidebar() {


### PR DESCRIPTION
## Summary
- activate the Deals sheet automatically when the sidebar is opened

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a21b89b483278f754f769e871182