### PR TITLE
Improve spreadsheet styling

### DIFF
--- a/installOnOpenMenuTrigger.gs
+++ b/installOnOpenMenuTrigger.gs
@@ -4,7 +4,7 @@ function onOpen(e) {
     .addItem(APP_CONFIG.MENU_NAME, 'openSidebar')
     .addItem('Log Date Differences', 'logDateDifferencesInRange')
     .addToUi();
-  setHeaderStyle();
+  applyFancySheetStyles();
 }
 
 function onInstall(e) {

--- a/processDealUrls.gs
+++ b/processDealUrls.gs
@@ -102,12 +102,14 @@ function checkAllUrls() {
     var status;
     if (resp && typeof resp.getResponseCode === 'function') {
       var code = resp.getResponseCode();
-      status = code === 200 ? '?' : '?';
-      if (status === '?') {
+      if (code >= 200 && code < 300) {
+        status = 'UP';
+      } else {
+        status = 'DOWN';
         downed.push(deal);
       }
     } else {
-      status = '??';
+      status = 'ERROR';
     }
     updates.push({ row: deal.row, status: status });
   }

--- a/sheetReadWriteFormatter.gs
+++ b/sheetReadWriteFormatter.gs
@@ -82,6 +82,7 @@ function hideRows(rowsToHide) {
   sheet.hideRows(start, count);
 }
 
+
 function setHeaderStyle() {
   var sheet = getSheet();
   var lastCol = sheet.getLastColumn();
@@ -92,11 +93,35 @@ function setHeaderStyle() {
        .setFontWeight('bold');
 }
 
+function applyFancySheetStyles() {
+  var sheet = getSheet();
+  var lastRow = sheet.getLastRow();
+  var lastCol = sheet.getLastColumn();
+  if (lastRow > 0) {
+    sheet.setRowHeights(1, lastRow, 60);
+  }
+  setHeaderStyle();
+  if (lastRow > 1 && lastCol > 0) {
+    var range = sheet.getRange(2, 1, lastRow - 1, lastCol);
+    var colors = [];
+    for (var r = 0; r < lastRow - 1; r++) {
+      var rowColor = (r % 2 === 0) ? '#f6f6ff' : '#ffffff';
+      var row = [];
+      for (var c = 0; c < lastCol; c++) {
+        row.push(rowColor);
+      }
+      colors.push(row);
+    }
+    range.setBackgrounds(colors);
+  }
+}
+
 var sheetReadWriteFormatter = {
   getSheet: getSheet,
   getSheetData: getSheetData,
   updateStatus: updateStatus,
   updateDaysLeft: updateDaysLeft,
   hideRows: hideRows,
-  setHeaderStyle: setHeaderStyle
+  setHeaderStyle: setHeaderStyle,
+  applyFancySheetStyles: applyFancySheetStyles
 };


### PR DESCRIPTION
## Summary
- style entire sheet with consistent row height and alternating colors
- fix URL status handling so downed sites show "DOWN" and unreachable sites "ERROR"
- call new styling function when the sheet opens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854a4787cd4832780e719a32fa2d1a1